### PR TITLE
Add support for common security headers

### DIFF
--- a/http/middleware/content_no_sniff.go
+++ b/http/middleware/content_no_sniff.go
@@ -1,0 +1,35 @@
+// Copyright 2017 Corey Scott http://www.sage42.org/
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package middleware
+
+import (
+	"net/http"
+)
+
+const (
+	xctoHeader = "X-Content-Type-Options"
+	xctoValue  = "nosniff"
+)
+
+// ContentNoSniff sends X-Content-Type-Options header.
+//
+// Reference: https://msdn.microsoft.com/en-us/library/gg622941%28v=vs.85%29.aspx
+func ContentNoSniff(handler http.Handler) http.HandlerFunc {
+	return http.HandlerFunc(func(resp http.ResponseWriter, req *http.Request) {
+		resp.Header().Set(xctoHeader, xctoValue)
+
+		handler.ServeHTTP(resp, req)
+	})
+}

--- a/http/middleware/content_no_sniff_examples_test.go
+++ b/http/middleware/content_no_sniff_examples_test.go
@@ -1,0 +1,34 @@
+// Copyright 2017 Corey Scott http://www.sage42.org/
+//
+// Licensed under the Apache License, ContentNoSniff 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package middleware_test
+
+import (
+	"log"
+	"net/http"
+
+	"github.com/corsc/go-commons/http/middleware"
+)
+
+func ExampleContentNoSniff_singleEndpoint() {
+	http.Handle("/foo", middleware.ContentNoSniff(http.HandlerFunc(fooHandler)))
+
+	log.Fatal(http.ListenAndServe(":8080", nil))
+}
+
+func ExampleContentNoSniff_allEndpoints() {
+	http.Handle("/foo", http.HandlerFunc(fooHandler))
+
+	log.Fatal(http.ListenAndServe(":8080", middleware.ContentNoSniff(http.DefaultServeMux)))
+}

--- a/http/middleware/content_no_sniff_test.go
+++ b/http/middleware/content_no_sniff_test.go
@@ -1,0 +1,40 @@
+// Copyright 2017 Corey Scott http://www.sage42.org/
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package middleware
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestContentNoSniff(t *testing.T) {
+	handler := getTestHandler()
+	expected := "nosniff"
+
+	handlerFunc := ContentNoSniff(handler)
+	assert.IsType(t, (http.HandlerFunc)(nil), handlerFunc)
+
+	resp := httptest.NewRecorder()
+	req, _ := http.NewRequest("GET", "/who-cares", nil)
+	handlerFunc(resp, req)
+
+	assert.True(t, handler.wasCalled())
+
+	result := resp.Header().Get(xctoHeader)
+	assert.Equal(t, expected, result)
+}

--- a/http/middleware/csp.go
+++ b/http/middleware/csp.go
@@ -1,0 +1,116 @@
+// Copyright 2017 Corey Scott http://www.sage42.org/
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package middleware
+
+import (
+	"net/http"
+
+	"github.com/corsc/go-commons/http/middleware/csp"
+)
+
+const (
+	cspHeader = "Content-Security-Policy"
+
+	cspPrefixDefault         = "default-src"
+	cspPrefixBase            = "base-uri"
+	cspPrefixChild           = "child-src"
+	cspPrefixConnect         = "connect-src"
+	cspPrefixFont            = "font-src"
+	cspPrefixForm            = "form-action"
+	cspPrefixFrame           = "frame-ancestors"
+	cspPrefixImage           = "img-src"
+	cspPrefixMedia           = "media-src"
+	cspPrefixObject          = "object-src"
+	cspPrefixPlugin          = "plugin-types"
+	cspPrefixReport          = "report-uri"
+	cspPrefixScript          = "script-src"
+	cspPrefixStyle           = "style-src"
+	cspPrefixUpgradeInsecure = "upgrade-insecure-requests"
+
+	cspSeparator = ";"
+)
+
+// CSP sends Content Security Policy header.
+//
+// Reference:
+// https://developer.mozilla.org/en-US/docs/Web/HTTP/CSP
+// https://www.html5rocks.com/en/tutorials/security/content-security-policy/
+func CSP(handler http.Handler, config *csp.Config) http.HandlerFunc {
+	return http.HandlerFunc(func(resp http.ResponseWriter, req *http.Request) {
+		value := ""
+		cspAdd(&value, cspPrefixDefault, config.Default)
+		cspAdd(&value, cspPrefixBase, config.Base)
+		cspAdd(&value, cspPrefixChild, config.Child)
+		cspAdd(&value, cspPrefixConnect, config.Connect)
+		cspAdd(&value, cspPrefixFont, config.Font)
+		cspAdd(&value, cspPrefixForm, config.Form)
+		cspAdd(&value, cspPrefixFrame, config.Frame)
+		cspAdd(&value, cspPrefixImage, config.Image)
+		cspAdd(&value, cspPrefixMedia, config.Media)
+		cspAdd(&value, cspPrefixObject, config.Object)
+		cspAdd(&value, cspPrefixPlugin, config.Plugin)
+		cspAdd(&value, cspPrefixScript, config.Script)
+		cspAdd(&value, cspPrefixStyle, config.Style)
+
+		cspAddString(&value, cspPrefixReport, config.Report)
+		cspAddBool(&value, cspPrefixUpgradeInsecure, config.UpgradeInsecure)
+
+		resp.Header().Set(cspHeader, value)
+
+		handler.ServeHTTP(resp, req)
+	})
+}
+
+func cspAdd(dest *string, prefix string, locations []string) {
+	if len(locations) == 0 {
+		return
+	}
+
+	if len(*dest) > 0 {
+		*dest += " "
+	}
+
+	*dest += prefix
+
+	for _, location := range locations {
+		*dest += " " + location
+	}
+
+	*dest += cspSeparator
+}
+
+func cspAddString(dest *string, prefix string, value string) {
+	if len(value) == 0 {
+		return
+	}
+
+	if len(*dest) > 0 {
+		*dest += " "
+	}
+
+	*dest += prefix + " " + value + cspSeparator
+}
+
+func cspAddBool(dest *string, output string, value bool) {
+	if !value {
+		return
+	}
+
+	if len(*dest) > 0 {
+		*dest += " "
+	}
+
+	*dest += output + cspSeparator
+}

--- a/http/middleware/csp/csp.go
+++ b/http/middleware/csp/csp.go
@@ -1,0 +1,73 @@
+// Copyright 2017 Corey Scott http://www.sage42.org/
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package csp
+
+const (
+	// None matches nothing (i.e. disable this media type)
+	None = "'none'"
+
+	// Self matches the current origin, but not its subdomains.
+	Self = "'self'"
+)
+
+// Config is the config for the CSP header
+// Note: all config is optional
+// Note: `None` and `Self` can be added to most of the settings in this struct
+type Config struct {
+	// Default serves as a fallback for the other CSP fetch directives
+	Default []string
+
+	// Base restricts the URLs that can appear in a page’s <base> element
+	Base []string
+
+	// Child lists the URLs for workers and embedded frame contents.
+	Child []string
+
+	// Connect limits the origins to which you can connect (via XHR, WebSockets, and EventSource).
+	Connect []string
+
+	// Font specifies the origins that can serve web fonts.
+	Font []string
+
+	// Form lists valid endpoints for submission from `<form>` tags
+	Form []string
+
+	// Frame specifies the sources that can embed the current page.
+	Frame []string
+
+	// Image defines the origins from which images can be loaded.
+	Image []string
+
+	// Media restricts the origins allowed to deliver video and audio.
+	Media []string
+
+	// Object allows control over Flash and other plugins.
+	Object []string
+
+	// Plugin limits the kinds of plugins a page may invoke.
+	Plugin []string
+
+	// Script defines the origins from which scripts can be loaded.
+	Script []string
+
+	// Style defines the origins from which stylesheets can be loaded.
+	Style []string
+
+	// Report specifies a URL where a browser will send reports when a content security policy is violated.
+	Report string
+
+	// UpgradeInsecure instructs user agents to rewrite URL schemes, changing HTTP to HTTPS.
+	UpgradeInsecure bool
+}

--- a/http/middleware/csp_examples_test.go
+++ b/http/middleware/csp_examples_test.go
@@ -1,0 +1,35 @@
+// Copyright 2017 Corey Scott http://www.sage42.org/
+//
+// Licensed under the Apache License, CSP 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package middleware_test
+
+import (
+	"log"
+	"net/http"
+
+	"github.com/corsc/go-commons/http/middleware"
+	"github.com/corsc/go-commons/http/middleware/csp"
+)
+
+func ExampleCSP_singleEndpoint() {
+	http.Handle("/foo", middleware.CSP(http.HandlerFunc(fooHandler), &csp.Config{Script: []string{csp.Self, "https://apis.google.com"}}))
+
+	log.Fatal(http.ListenAndServe(":8080", nil))
+}
+
+func ExampleCSP_allEndpoints() {
+	http.Handle("/foo", http.HandlerFunc(fooHandler))
+
+	log.Fatal(http.ListenAndServe(":8080", middleware.CSP(http.DefaultServeMux, &csp.Config{Script: []string{csp.Self, "https://apis.google.com"}})))
+}

--- a/http/middleware/csp_test.go
+++ b/http/middleware/csp_test.go
@@ -1,0 +1,201 @@
+// Copyright 2017 Corey Scott http://www.sage42.org/
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package middleware
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/corsc/go-commons/http/middleware/csp"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestCSP(t *testing.T) {
+	scenarios := []struct {
+		desc     string
+		config   *csp.Config
+		expected string
+	}{
+		{
+			desc: "default",
+			config: &csp.Config{
+				Default: []string{"https:"},
+			},
+			expected: "default-src https:;",
+		},
+		{
+			desc: "base",
+			config: &csp.Config{
+				Base: []string{csp.Self, "https://*.example.com/"},
+			},
+			expected: "base-uri 'self' https://*.example.com/;",
+		},
+		{
+			desc: "child",
+			config: &csp.Config{
+				Child: []string{csp.Self, "https://youtube.com/"},
+			},
+			expected: "child-src 'self' https://youtube.com/;",
+		},
+		{
+			desc: "connect",
+			config: &csp.Config{
+				Connect: []string{csp.Self, "https://example.com/"},
+			},
+			expected: "connect-src 'self' https://example.com/;",
+		},
+		{
+			desc: "font",
+			config: &csp.Config{
+				Font: []string{csp.Self, "https://themes.googleusercontent.com"},
+			},
+			expected: "font-src 'self' https://themes.googleusercontent.com;",
+		},
+		{
+			desc: "form",
+			config: &csp.Config{
+				Form: []string{csp.Self, "https://example.com/"},
+			},
+			expected: "form-action 'self' https://example.com/;",
+		},
+		{
+			desc: "frame",
+			config: &csp.Config{
+				Frame: []string{csp.Self, "https://example.com/"},
+			},
+			expected: "frame-ancestors 'self' https://example.com/;",
+		},
+		{
+			desc: "image",
+			config: &csp.Config{
+				Image: []string{csp.Self, "https://youtube.com/"},
+			},
+			expected: "img-src 'self' https://youtube.com/;",
+		},
+		{
+			desc: "media",
+			config: &csp.Config{
+				Media: []string{csp.Self, "https://youtube.com/"},
+			},
+			expected: "media-src 'self' https://youtube.com/;",
+		},
+		{
+			desc: "object",
+			config: &csp.Config{
+				Object: []string{csp.Self, "https://example.com/"},
+			},
+			expected: "object-src 'self' https://example.com/;",
+		},
+		{
+			desc: "plugin",
+			config: &csp.Config{
+				Plugin: []string{"application/x-shockwave-flash", "application/x-java-applet"},
+			},
+			expected: "plugin-types application/x-shockwave-flash application/x-java-applet;",
+		},
+		{
+			desc: "script",
+			config: &csp.Config{
+				Script: []string{csp.Self, "https://apis.google.com"},
+			},
+			expected: "script-src 'self' https://apis.google.com;",
+		},
+		{
+			desc: "style",
+			config: &csp.Config{
+				Style: []string{csp.Self, "http://*.example.com", "'unsafe-inline'"},
+			},
+			expected: "style-src 'self' http://*.example.com 'unsafe-inline';",
+		},
+		{
+			desc: "report",
+			config: &csp.Config{
+				Report: "/csp-report-endpoint",
+			},
+			expected: "report-uri /csp-report-endpoint;",
+		},
+		{
+			desc: "upgrade insecure",
+			config: &csp.Config{
+				UpgradeInsecure: true,
+			},
+			expected: "upgrade-insecure-requests;",
+		},
+	}
+
+	for _, scenario := range scenarios {
+		t.Run(scenario.desc, func(t *testing.T) {
+			handler := getTestHandler()
+
+			handlerFunc := CSP(handler, scenario.config)
+			assert.IsType(t, (http.HandlerFunc)(nil), handlerFunc)
+
+			resp := httptest.NewRecorder()
+			req, _ := http.NewRequest("GET", "/who-cares", nil)
+			handlerFunc(resp, req)
+
+			assert.True(t, handler.wasCalled())
+
+			result := resp.Header().Get(cspHeader)
+			assert.Equal(t, scenario.expected, result)
+		})
+	}
+}
+
+func TestCSP_extended(t *testing.T) {
+	config := &csp.Config{
+		Script:          []string{csp.Self, "https://apis.google.com"},
+		UpgradeInsecure: true,
+	}
+	expected := "script-src 'self' https://apis.google.com; upgrade-insecure-requests;"
+
+	handler := getTestHandler()
+
+	handlerFunc := CSP(handler, config)
+	assert.IsType(t, (http.HandlerFunc)(nil), handlerFunc)
+
+	resp := httptest.NewRecorder()
+	req, _ := http.NewRequest("GET", "/who-cares", nil)
+	handlerFunc(resp, req)
+
+	assert.True(t, handler.wasCalled())
+
+	result := resp.Header().Get(cspHeader)
+	assert.Equal(t, expected, result)
+}
+
+func TestCSP_cdn(t *testing.T) {
+	config := &csp.Config{
+		Default: []string{"https://cdn.example.net"},
+		Child:   []string{csp.None},
+		Object:  []string{csp.None},
+	}
+	expected := "default-src https://cdn.example.net; child-src 'none'; object-src 'none';"
+
+	handler := getTestHandler()
+
+	handlerFunc := CSP(handler, config)
+	assert.IsType(t, (http.HandlerFunc)(nil), handlerFunc)
+
+	resp := httptest.NewRecorder()
+	req, _ := http.NewRequest("GET", "/who-cares", nil)
+	handlerFunc(resp, req)
+
+	assert.True(t, handler.wasCalled())
+
+	result := resp.Header().Get(cspHeader)
+	assert.Equal(t, expected, result)
+}

--- a/http/middleware/hsts.go
+++ b/http/middleware/hsts.go
@@ -1,0 +1,45 @@
+// Copyright 2017 Corey Scott http://www.sage42.org/
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package middleware
+
+import (
+	"net/http"
+	"strconv"
+	"time"
+)
+
+const (
+	hstsHeader     = "Strict-Transport-Security"
+	hstsMaxAge     = "max-age="
+	hstsIncludeSub = "; includeSubDomains"
+)
+
+// HSTS sends HTTP Strict Transport Security header.
+//
+// By default the "includeSubDomains" is added; which is recommended.
+//
+// Reference: https://www.owasp.org/index.php/HTTP_Strict_Transport_Security_Cheat_Sheet
+func HSTS(handler http.Handler, maxAge time.Duration, excludeSubDomains ...bool) http.HandlerFunc {
+	return http.HandlerFunc(func(resp http.ResponseWriter, req *http.Request) {
+		value := hstsMaxAge + strconv.FormatInt(int64(maxAge.Seconds()), 10)
+		if len(excludeSubDomains) == 0 || !excludeSubDomains[0] {
+			value += hstsIncludeSub
+		}
+
+		resp.Header().Set(hstsHeader, value)
+
+		handler.ServeHTTP(resp, req)
+	})
+}

--- a/http/middleware/hsts_examples_test.go
+++ b/http/middleware/hsts_examples_test.go
@@ -1,0 +1,35 @@
+// Copyright 2017 Corey Scott http://www.sage42.org/
+//
+// Licensed under the Apache License, HSTS 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package middleware_test
+
+import (
+	"log"
+	"net/http"
+	"time"
+
+	"github.com/corsc/go-commons/http/middleware"
+)
+
+func ExampleHSTS_singleEndpoint() {
+	http.Handle("/foo", middleware.HSTS(http.HandlerFunc(fooHandler), 365*24*time.Hour))
+
+	log.Fatal(http.ListenAndServe(":8080", nil))
+}
+
+func ExampleHSTS_allEndpoints() {
+	http.Handle("/foo", http.HandlerFunc(fooHandler))
+
+	log.Fatal(http.ListenAndServe(":8080", middleware.HSTS(http.DefaultServeMux, 365*24*time.Hour)))
+}

--- a/http/middleware/hsts_test.go
+++ b/http/middleware/hsts_test.go
@@ -1,0 +1,42 @@
+// Copyright 2017 Corey Scott http://www.sage42.org/
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package middleware
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestHSTS(t *testing.T) {
+	handler := getTestHandler()
+	oneWeek := 7 * 24 * time.Hour
+	expected := "max-age=604800; includeSubDomains"
+
+	handlerFunc := HSTS(handler, oneWeek)
+	assert.IsType(t, (http.HandlerFunc)(nil), handlerFunc)
+
+	resp := httptest.NewRecorder()
+	req, _ := http.NewRequest("GET", "/who-cares", nil)
+	handlerFunc(resp, req)
+
+	assert.True(t, handler.wasCalled())
+
+	result := resp.Header().Get(hstsHeader)
+	assert.Equal(t, expected, result)
+}

--- a/http/middleware/xxss.go
+++ b/http/middleware/xxss.go
@@ -1,0 +1,43 @@
+// Copyright 2017 Corey Scott http://www.sage42.org/
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package middleware
+
+import (
+	"net/http"
+)
+
+const (
+	xxssHeader = "X-XSS-Protection"
+	xxssValue  = "1"
+	xxssBlock  = "; mode=block"
+)
+
+// XXSS sends X-XSS-Protection response header
+//
+// By default the "mode=block" is not sent.
+//
+// Reference: https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/X-XSS-Protection
+func XXSS(handler http.Handler, block ...bool) http.HandlerFunc {
+	return http.HandlerFunc(func(resp http.ResponseWriter, req *http.Request) {
+		value := xxssValue
+		if len(block) > 0 && block[0] {
+			value += xxssBlock
+		}
+
+		resp.Header().Set(xxssHeader, value)
+
+		handler.ServeHTTP(resp, req)
+	})
+}

--- a/http/middleware/xxss_examples_test.go
+++ b/http/middleware/xxss_examples_test.go
@@ -1,0 +1,34 @@
+// Copyright 2017 Corey Scott http://www.sage42.org/
+//
+// Licensed under the Apache License, XXSS 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package middleware_test
+
+import (
+	"log"
+	"net/http"
+
+	"github.com/corsc/go-commons/http/middleware"
+)
+
+func ExampleXXSS_singleEndpoint() {
+	http.Handle("/foo", middleware.XXSS(http.HandlerFunc(fooHandler), true))
+
+	log.Fatal(http.ListenAndServe(":8080", nil))
+}
+
+func ExampleXXSS_allEndpoints() {
+	http.Handle("/foo", http.HandlerFunc(fooHandler))
+
+	log.Fatal(http.ListenAndServe(":8080", middleware.XXSS(http.DefaultServeMux, true)))
+}

--- a/http/middleware/xxss_test.go
+++ b/http/middleware/xxss_test.go
@@ -1,0 +1,60 @@
+// Copyright 2017 Corey Scott http://www.sage42.org/
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package middleware
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestXXSS(t *testing.T) {
+	scenarios := []struct {
+		desc      string
+		extraArgs []bool
+		expected  string
+	}{
+		{
+			desc:      "no block",
+			extraArgs: nil,
+			expected:  "1",
+		},
+		{
+			desc:      "with block",
+			extraArgs: []bool{true},
+			expected:  "1; mode=block",
+		},
+	}
+
+	for _, scenario := range scenarios {
+		t.Run(scenario.desc, func(t *testing.T) {
+			handler := getTestHandler()
+
+			handlerFunc := XXSS(handler, scenario.extraArgs...)
+			assert.IsType(t, (http.HandlerFunc)(nil), handlerFunc)
+
+			resp := httptest.NewRecorder()
+			req, _ := http.NewRequest("GET", "/who-cares", nil)
+			handlerFunc(resp, req)
+
+			assert.True(t, handler.wasCalled())
+
+			result := resp.Header().Get(xxssHeader)
+			assert.Equal(t, scenario.expected, result)
+		})
+	}
+}


### PR DESCRIPTION
Added support for:
* `X-Content-Type-Options`
* `Content Security Policy`
* `Strict-Transport-Security`
* `X-XSS-Protection`


Closes https://github.com/corsc/go-commons/issues/27