### PR TITLE
Add NetTest package

### DIFF
--- a/testing/nettest/README.md
+++ b/testing/nettest/README.md
@@ -1,3 +1,17 @@
 # Nettest
 
 This package provides a simple way to get an open TCP/UDP port that can then be used for testing.
+
+## Example Usage
+```go
+port := nettest.GetTCP()
+
+address := net.JoinHostPort("0.0.0.0", strconv.Itoa(port))
+
+listener, err := net.Listen("tcp", address)
+if err != nil {
+    return err
+}
+
+rpc.Accept(listener)
+```

--- a/testing/nettest/README.md
+++ b/testing/nettest/README.md
@@ -1,0 +1,3 @@
+# Nettest
+
+This package provides a simple way to get an open TCP/UDP port that can then be used for testing.

--- a/testing/nettest/doc.go
+++ b/testing/nettest/doc.go
@@ -1,0 +1,20 @@
+// Copyright 2020 Corey Scott http://www.sage42.org/
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Package nettest please refer to README.md
+package nettest
+
+func init() {
+	// this code is included to avoid "no valid go files" or "invalid go package" errors
+}

--- a/testing/nettest/nettest.go
+++ b/testing/nettest/nettest.go
@@ -1,0 +1,51 @@
+package nettest
+
+import (
+	"net"
+	"strconv"
+	"strings"
+)
+
+// GetTCP returns a TCP port that is available for use.
+//
+// NOTE: in the very rare case when no ports are available, this method will panic
+func GetTCP() int {
+	address := net.JoinHostPort("localhost", "0")
+	listener, err := net.Listen("tcp", address)
+	if err != nil {
+		panic(err)
+	}
+
+	defer func() {
+		_ = listener.Close()
+	}()
+
+	return getPortNo(listener.Addr().String())
+}
+
+// GetUDP returns a UDP port that is available for use.
+//
+// NOTE: in the very rare case when no ports are available, this method will panic
+func GetUDP() int {
+	address := net.JoinHostPort("localhost", "0")
+	listener, err := net.ListenPacket("udp", address)
+	if err != nil {
+		panic(err)
+	}
+
+	defer func() {
+		_ = listener.Close()
+	}()
+
+	return getPortNo(listener.LocalAddr().String())
+}
+
+func getPortNo(address string) int {
+	chunks := strings.Split(address, ":")
+	port, err := strconv.Atoi(chunks[len(chunks)-1])
+	if err != nil {
+		panic(err)
+	}
+
+	return port
+}

--- a/testing/nettest/nettest_test.go
+++ b/testing/nettest/nettest_test.go
@@ -1,0 +1,33 @@
+package nettest
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestGetTCP(t *testing.T) {
+	var results []int
+
+	for x := 0; x < 20; x++ {
+		port := GetTCP()
+
+		assert.NotEqual(t, 0, port, "port should not be 0")
+		assert.NotContains(t, results, port, "port should not repeat")
+
+		results = append(results, port)
+	}
+}
+
+func TestGetUDP(t *testing.T) {
+	var results []int
+
+	for x := 0; x < 20; x++ {
+		port := GetUDP()
+
+		assert.NotEqual(t, 0, port, "port should not be 0")
+		assert.NotContains(t, results, port, "port should not repeat")
+
+		results = append(results, port)
+	}
+}


### PR DESCRIPTION
This package provides a simple way to get an open TCP/UDP port that can then be used for testing.